### PR TITLE
add build for arm64

### DIFF
--- a/Dockerfile.xcompile
+++ b/Dockerfile.xcompile
@@ -14,4 +14,4 @@ COPY registry     /go/src/github.com/realestate-com-au/dfresh/registry
 
 WORKDIR /go/src/github.com/realestate-com-au/dfresh
 
-RUN gox -osarch "linux/amd64 darwin/amd64"
+RUN gox -osarch "linux/amd64 linux/arm64 darwin/amd64"


### PR DESCRIPTION
build dfresh binary for linux/arm64, so we can run on AWS a1 instances.